### PR TITLE
docs/source/index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,3 +20,5 @@ Contents
 
    usage
    api
+
+Lumache has its documentation hosted on Read the Docs.


### PR DESCRIPTION
Lumache has its documentation hosted on Read the Docs.